### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-pr-label.yml
+++ b/.github/workflows/dev-pr-label.yml
@@ -18,6 +18,8 @@ jobs:
   label_check:
     name: Check PR Labels
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node-version: [20.x]

--- a/.github/workflows/dev-pr-label.yml
+++ b/.github/workflows/dev-pr-label.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
+
     strategy:
       matrix:
         node-version: [20.x]

--- a/.github/workflows/hygiene-checks.yml
+++ b/.github/workflows/hygiene-checks.yml
@@ -6,6 +6,7 @@ name: Hygiene Checks
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   push:

--- a/.github/workflows/hygiene-checks.yml
+++ b/.github/workflows/hygiene-checks.yml
@@ -6,7 +6,6 @@ name: Hygiene Checks
 
 permissions:
   contents: read
-  pull-requests: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RussOakham/macro-ai/security/code-scanning/3](https://github.com/RussOakham/macro-ai/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks labels on pull requests, it requires minimal permissions. The `contents: read` permission is sufficient for accessing repository data, and no write permissions are needed. The `permissions` block should be added at the job level (`label_check`) to limit the scope of permissions to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to improve access control for automated label checks on pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->